### PR TITLE
Propagate extra keyword arguments to the Kafka library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.0.4] -- 2022-01-28
+
+* Propagate extra arguments to the Kafka library (e.g. for authentication)
+
 ## [0.0.3] -- 2021-07-06
 
 * Fixed package name

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It takes care of:
 * publishing the associated schema (or updating an existing one)
 * serializing and publishing messages to Kafka
 
-It works with [kafka-python][]
+It works with [kafka-python][], and extra arguments are forwarded to it.
 
 [kafka-python]: https://github.com/dpkp/kafka-python
 

--- a/kafka_schema_registry/__init__.py
+++ b/kafka_schema_registry/__init__.py
@@ -108,6 +108,7 @@ def create_topic(
     topic_name: str,
     num_partitions: int,
     replication_factor: int,
+    **kwargs,
 ):
     """Create a topic with the given number of partitions.
 
@@ -127,7 +128,10 @@ def create_topic(
     try:
         # WORKAROUND: see https://github.com/dpkp/kafka-python/pull/2048
         # when done remove this try catch
-        admin_client = KafkaAdminClient(bootstrap_servers=bootstrap_servers)
+        admin_client = KafkaAdminClient(
+            bootstrap_servers=bootstrap_servers,
+            **kwargs,
+        )
     except NoBrokersAvailable:
         logger.warning('Error instantiating the client, should be solved by'
                        'https://github.com/dpkp/kafka-python/pull/2048')
@@ -153,6 +157,7 @@ def prepare_producer(
     replication_factor: int,
     value_schema: dict = None,
     key_schema: dict = None,
+    **kwargs,
         ):
     """Ensure the topic and the schema exist and returns a producer for it.
 
@@ -189,6 +194,7 @@ def prepare_producer(
         topic_name,
         num_partitions,
         replication_factor,
+        **kwargs,
     )
 
     parsed_value_schema = None
@@ -268,4 +274,6 @@ def prepare_producer(
         api_version_auto_timeout_ms=10 * 1000,
         # accumulate messages for these ms before sending them
         linger_ms=1000,
+        # propagate extra arguments
+        **kwargs,
         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-pytest==6.2.4
-pytest-cov==2.12.0
-flake8==3.9.0
-responses==0.13.3
-twine==3.4.1
-wheel==0.36.2
+pytest==6.2.5
+pytest-cov==3.0.0
+flake8==4.0.1
+responses==0.17.0
+twine==3.7.1
+wheel==0.37.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fastavro==1.4.1
+fastavro==1.4.9
 kafka-python==2.0.2
-requests==2.25.1
+requests==2.27.1


### PR DESCRIPTION
This PR adds the possibility to pass extra arguments to the Kafka library, for example in order to use SASL authentication