### PR TITLE
Support string key schemas

### DIFF
--- a/kafka_schema_registry/__init__.py
+++ b/kafka_schema_registry/__init__.py
@@ -232,15 +232,16 @@ def prepare_producer(
 
     parsed_key_schema = None
     default_keys = {}
-    if key_schema is not None and key_schema != "string":
+    if key_schema is not None:
         parsed_key_schema = parse_schema(key_schema)
-        # store the default values to remove
-        # the values from the messages when identical
-        default_keys = {
-            field['name']: field['default']
-            for field in parsed_key_schema['fields']
-            if 'default' in field
-        }
+        if key_schema != "string":
+            # store the default values to remove
+            # the values from the messages when identical
+            default_keys = {
+                field['name']: field['default']
+                for field in parsed_key_schema['fields']
+                if 'default' in field
+            }
 
     key_schema_id, value_schema_id = publish_schemas(
         topic_name,

--- a/kafka_schema_registry/__init__.py
+++ b/kafka_schema_registry/__init__.py
@@ -232,7 +232,7 @@ def prepare_producer(
 
     parsed_key_schema = None
     default_keys = {}
-    if key_schema is not None:
+    if key_schema is not None and key_schema != "string":
         parsed_key_schema = parse_schema(key_schema)
         # store the default values to remove
         # the values from the messages when identical

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-fastavro==1.11.1
-kafka-python==2.2.15
-requests==2.32.4
+fastavro==1.12.1
+kafka-python==2.3.0
+requests==2.32.5


### PR DESCRIPTION
With this change it's possible to define a schema that is just "string", previously it broke because we assumed it was an object and tried to parse its default values